### PR TITLE
Fix issue #54

### DIFF
--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -48,8 +48,12 @@ export class CookieService {
 
       const regExp: RegExp = this.getCookieRegExp( name );
       const result: RegExpExecArray = regExp.exec( this.document.cookie );
-
-      return decodeURIComponent( result[ 1 ] );
+      try {
+        return decodeURIComponent( result[ 1 ] );
+      } catch (error) {
+        // the cookie probably is not uri encoded. return as is
+        return result[ 1 ];
+      }
     } else {
       return '';
     }


### PR DESCRIPTION
When cookie is not set with this library, it is possible that the val is not uri encoded, and perform decodeURIComponent on the value
will throw an error. This fix catch the error, and return the raw string.