### PR TITLE
Fix problem with cookies not being deleted

### DIFF
--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -136,12 +136,12 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete( name: string, path?: string, domain?: string ): void {
+  delete( name: string, path?: string, domain?: string, secure?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'None' ): void {
     if ( !this.documentIsAccessible ) {
       return;
     }
 
-    this.set( name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain );
+    this.set( name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain, secure, sameSite );
   }
 
   /**


### PR DESCRIPTION
The problem arises in Chrome when having inconsistent cookie attributes. Until now, it was assumed `Secure=false; SameSite=None` and it is impossible to delete those cookies with different values for either Secure or SameSite.