### PR TITLE
Force secure flag if sameSite=none

### DIFF
--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -125,7 +125,13 @@ export class CookieService {
       cookieString += 'domain=' + domain + ';';
     }
 
-    if ( secure ) {
+    if ( secure === false && sameSite === 'None') {
+      secure = true;
+      console.warn(`[ngx-cookie-service] Cookie ${name} was forced with secure flag because sameSite=None.` +
+        `More details : https://github.com/stevermeister/ngx-cookie-service/issues/86#issuecomment-597720130`);
+    }
+
+    if (secure) {
       cookieString += 'secure;';
     }
 


### PR DESCRIPTION
Should fix #86 

Browsers now reject cookies setted with sameSite=none if secure flag isn't set.

This PR override the `secure` flag with a warning if sameSite=none