### PR TITLE
Add new flag coockie

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "tabWidth": 2,
-  "printWidth": 140,
+  "printWidth": 160,
   "singleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const allCookies: {} = cookieService.getAll();
 
 Returns a map of key-value pairs for cookies that can be accessed.
 
-## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: 'Lax' | 'Strict' | 'None' ): void;
+## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite?: 'Lax' | 'Strict' | 'None' ): void;
 
 ```typescript
 cookieService.set( 'test', 'Hello World' );
@@ -78,7 +78,7 @@ Sets a cookie with the specified `name` and `value`. It is good practice to spec
 
 **Important:** Browsers do not accept cookies flagged sameSite = 'None' if secure flag isn't set as well. CookieService will override the secure flag to true if sameSite='None'.
 
-## delete( name: string, path?: string, domain?: string, secure?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax' ): void;
+## delete( name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax' ): void;
 
 ```typescript
 cookieService.delete('test');
@@ -88,7 +88,7 @@ Deletes a cookie with the specified `name`.  It is best practice to always defin
 
 **Important:** For security reasons, it is not possible to delete cookies for other domains. Browsers do not allow this. Read [this](https://stackoverflow.com/a/1063760) and [this](https://stackoverflow.com/a/17777005/1007003) StackOverflow answer for a more in-depth explanation.
 
-## deleteAll( path?: string, domain?: string, secure?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax' ): void;
+## deleteAll( path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax' ): void;
 
 ```typescript
 cookieService.deleteAll();
@@ -162,6 +162,7 @@ Thanks to all contributors:
 * [DBaker85](https://github.com/DBaker85)
 * [mattlewis92](https://github.com/mattlewis92)
 * [IceBreakerG](https://github.com/IceBreakerG)
+* [rojedalopez](https://github.com/rojedalopez)
 
 # License
 

--- a/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
@@ -212,9 +212,9 @@ describe('NgxCookieServiceService', () => {
       });
       it('should invoke set method with fixed date and and pass other params through', () => {
         spyOn(cookieService, 'set');
-        cookieService.delete('foo', '/test', 'example.com', true, 'Lax');
+        cookieService.delete('foo', '/test', 'example.com', true, true, 'Lax');
 
-        expect(cookieService.set).toHaveBeenCalledWith('foo', '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), '/test', 'example.com', true, 'Lax');
+        expect(cookieService.set).toHaveBeenCalledWith('foo', '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), '/test', 'example.com', true, true, 'Lax');
       });
     });
     describe('#deleteAll', () => {
@@ -231,10 +231,10 @@ describe('NgxCookieServiceService', () => {
         documentMock.cookie = 'foo=bar';
         documentMock.cookie = 'test=test123';
         expect(documentMock.cookie).toEqual('foo=bar; test=test123');
-        cookieService.deleteAll('/test', 'example.com', true, 'Lax');
+        cookieService.deleteAll('/test', 'example.com', true, true, 'Lax');
 
-        expect(cookieService.delete).toHaveBeenCalledWith('foo', '/test', 'example.com', true, 'Lax');
-        expect(cookieService.delete).toHaveBeenCalledWith('test', '/test', 'example.com', true, 'Lax');
+        expect(cookieService.delete).toHaveBeenCalledWith('foo', '/test', 'example.com', true, true, 'Lax');
+        expect(cookieService.delete).toHaveBeenCalledWith('test', '/test', 'example.com', true, true,'Lax');
       });
     });
   });

--- a/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
@@ -181,26 +181,26 @@ describe('NgxCookieServiceService', () => {
         expect(documentCookieSetterSpy).toHaveBeenCalledWith('foo=bar;domain=example.com;sameSite=Lax;');
       });
       it('should set cookie with secure option', () => {
-        cookieService.set('foo', 'bar', undefined, undefined, undefined, true);
+        cookieService.set('foo', 'bar', undefined, undefined, undefined, true, true);
 
-        expect(documentCookieSetterSpy).toHaveBeenCalledWith('foo=bar;secure;sameSite=Lax;');
+        expect(documentCookieSetterSpy).toHaveBeenCalledWith('foo=bar;secure;HttpOnly;sameSite=Lax;');
       });
       it('should set cookie with forced secure flag when SameSite option is "None"', () => {
-        cookieService.set('foo', 'bar', undefined, undefined, undefined, false, 'None');
+        cookieService.set('foo', 'bar', undefined, undefined, undefined, false, false, 'None');
 
-        expect(documentCookieSetterSpy).toHaveBeenCalledWith('foo=bar;secure;sameSite=None;');
+        expect(documentCookieSetterSpy).toHaveBeenCalledWith('foo=bar;secure;HttpOnly;sameSite=None;');
       });
       it('should set cookie with SameSite option', () => {
-        cookieService.set('foo', 'bar', undefined, undefined, undefined, false, 'Strict');
+        cookieService.set('foo', 'bar', undefined, undefined, undefined, false, false, 'Strict');
 
         expect(documentCookieSetterSpy).toHaveBeenCalledWith('foo=bar;sameSite=Strict;');
       });
       it('should set cookie with all options', () => {
         const expiresDate = new Date('Mon, 15 Mar 2021 10:00:00 GMT');
-        cookieService.set('foo', 'bar', expiresDate, '/test', 'example.com', true, 'Strict');
+        cookieService.set('foo', 'bar', expiresDate, '/test', 'example.com', true, true, 'Strict');
 
         expect(documentCookieSetterSpy).toHaveBeenCalledWith(
-          'foo=bar;expires=Mon, 15 Mar 2021 10:00:00 GMT;path=/test;domain=example.com;secure;sameSite=Strict;'
+          'foo=bar;expires=Mon, 15 Mar 2021 10:00:00 GMT;path=/test;domain=example.com;secure;HttpOnly;sameSite=Strict;'
         );
       });
     });

--- a/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
@@ -234,7 +234,7 @@ describe('NgxCookieServiceService', () => {
         cookieService.deleteAll('/test', 'example.com', true, true, 'Lax');
 
         expect(cookieService.delete).toHaveBeenCalledWith('foo', '/test', 'example.com', true, true, 'Lax');
-        expect(cookieService.delete).toHaveBeenCalledWith('test', '/test', 'example.com', true, true,'Lax');
+        expect(cookieService.delete).toHaveBeenCalledWith('test', '/test', 'example.com', true, true, 'Lax');
       });
     });
   });

--- a/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
@@ -116,9 +116,7 @@ describe('NgxCookieServiceService', () => {
         expect(cookieService.getAll()).toEqual({ foo: 'bar', Hello: 'World', ';,/?:@&=+$': ';,/?:@&=+$' });
       });
       it('should return object with safely decoded cookie names and values', () => {
-        documentCookieGetterSpy.and.returnValue(
-          'foo=%E0%A4%A; %E0%A4%A=%E0%A4%A; Hello=World; %3B%2C%2F%3F%3A%40%26%3D%2B%24=%3B%2C%2F%3F%3A%40%26%3D%2B%24'
-        );
+        documentCookieGetterSpy.and.returnValue('foo=%E0%A4%A; %E0%A4%A=%E0%A4%A; Hello=World; %3B%2C%2F%3F%3A%40%26%3D%2B%24=%3B%2C%2F%3F%3A%40%26%3D%2B%24');
 
         expect(cookieService.getAll()).toEqual({
           foo: '%E0%A4%A',
@@ -216,15 +214,7 @@ describe('NgxCookieServiceService', () => {
         spyOn(cookieService, 'set');
         cookieService.delete('foo', '/test', 'example.com', true, 'Lax');
 
-        expect(cookieService.set).toHaveBeenCalledWith(
-          'foo',
-          '',
-          new Date('Thu, 01 Jan 1970 00:00:01 GMT'),
-          '/test',
-          'example.com',
-          true,
-          'Lax'
-        );
+        expect(cookieService.set).toHaveBeenCalledWith('foo', '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), '/test', 'example.com', true, 'Lax');
       });
     });
     describe('#deleteAll', () => {

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -154,12 +154,14 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(name: string, 
+  delete(
+          name: string, 
           path?: string, 
           domain?: string, 
           secure?: boolean, 
           httpOnly?: boolean, 
-          sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
+          sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'
+  ): void {
     if (!this.documentIsAccessible) {
       return;
     }

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -154,14 +154,7 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(
-          name: string, 
-          path?: string, 
-          domain?: string, 
-          secure?: boolean, 
-          httpOnly?: boolean, 
-          sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'
-  ): void {
+  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax'|'None'|'Strict'='Lax'): void {
     if (!this.documentIsAccessible) {
       return;
     }

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -154,7 +154,12 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
+  delete(name: string, 
+          path?: string, 
+          domain?: string, 
+          secure?: boolean, 
+          httpOnly?: boolean, 
+          sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
     if (!this.documentIsAccessible) {
       return;
     }

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -154,7 +154,7 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): 
+  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'):
   void {
     if (!this.documentIsAccessible) {
       return;

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -154,7 +154,8 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax'|'None'|'Strict'='Lax'): void {
+  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): 
+  void {
     if (!this.documentIsAccessible) {
       return;
     }

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -130,6 +130,10 @@ export class CookieService {
       );
     }
       
+    if (secure) {
+      cookieString += 'secure;';
+    }
+      
     if (httpOnly === false && sameSite === 'None') {
       httpOnly = true;
       console.warn(

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -85,6 +85,7 @@ export class CookieService {
    * @param path     Cookie path
    * @param domain   Cookie domain
    * @param secure   Secure flag
+   * @param httpOnly HttpOnly flag
    * @param sameSite OWASP samesite token `Lax`, `None`, or `Strict`. Defaults to `Lax`
    */
   set(
@@ -94,6 +95,7 @@ export class CookieService {
     path?: string,
     domain?: string,
     secure?: boolean,
+    httpOnly?: boolean,
     sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'
   ): void {
     if (!this.documentIsAccessible) {
@@ -127,9 +129,17 @@ export class CookieService {
           `More details : https://github.com/stevermeister/ngx-cookie-service/issues/86#issuecomment-597720130`
       );
     }
+      
+    if (httpOnly === false && sameSite === 'None') {
+      httpOnly = true;
+      console.warn(
+        `[ngx-cookie-service] Cookie ${name} was forced with httpOnly flag because sameSite=None.` +
+          `More details : https://github.com/stevermeister/ngx-cookie-service/issues/86#issuecomment-597720130`
+      );
+    }
 
-    if (secure) {
-      cookieString += 'secure;';
+    if (httpOnly) {
+      cookieString += 'HttpOnly;';
     }
 
     cookieString += 'sameSite=' + sameSite + ';';
@@ -142,19 +152,19 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(name: string, path?: string, domain?: string, secure?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
+  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
     if (!this.documentIsAccessible) {
       return;
     }
 
-    this.set(name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain, secure, sameSite);
+    this.set(name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain, secure, httpOnly, sameSite);
   }
 
   /**
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  deleteAll(path?: string, domain?: string, secure?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
+  deleteAll(path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
     if (!this.documentIsAccessible) {
       return;
     }
@@ -163,7 +173,7 @@ export class CookieService {
 
     for (const cookieName in cookies) {
       if (cookies.hasOwnProperty(cookieName)) {
-        this.delete(cookieName, path, domain, secure, sameSite);
+        this.delete(cookieName, path, domain, secure, httpOnly, sameSite);
       }
     }
   }

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -154,8 +154,7 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'):
-  void {
+  delete(name: string, path?: string, domain?: string, secure?: boolean, httpOnly?: boolean, sameSite: 'Lax' | 'None' | 'Strict' = 'Lax'): void {
     if (!this.documentIsAccessible) {
       return;
     }

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -129,11 +129,9 @@ export class CookieService {
           `More details : https://github.com/stevermeister/ngx-cookie-service/issues/86#issuecomment-597720130`
       );
     }
-      
     if (secure) {
       cookieString += 'secure;';
     }
-      
     if (httpOnly === false && sameSite === 'None') {
       httpOnly = true;
       console.warn(

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,7 @@
     "import-blacklist": [true, "rxjs/Rx"],
     "interface-name": false,
     "max-classes-per-file": false,
-    "max-line-length": [true, 140],
+    "max-line-length": [true, 160],
     "member-access": false,
     "member-ordering": [
       true,


### PR DESCRIPTION
@stevermeister => the HttpOnly flag (optional) is included in the HTTP response header, the cookie cannot be accessed through the client-side script (again if the browser supports this flag). As a result, even if a cross-site scripting (XSS) exists, it fails, and a user accidentally accesses a link that exploits this failure, the browser (mainly Internet Explorer) does not reveal the cookie to a third party. If a browser does not support HttpOnly and a website tries to set an HttpOnly cookie, the HttpOnly flag will be ignored by the browser, thus creating an accessible traditional Cookie script. As a result, the cookie (becomes a session cookie) becomes vulnerable to modification theft through malicious script.