### PR TITLE
chore(core): enables partial-Ivy compilation to transition libraries to partial-Ivy format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6822,7 +6822,8 @@
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "injection-js": {

--- a/projects/ngx-cookie-service/tsconfig.lib.prod.json
+++ b/projects/ngx-cookie-service/tsconfig.lib.prod.json
@@ -4,6 +4,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": false
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
This PR enables partial-Ivy compilation to transition libraries to partial-Ivy format. See https://angular.io/guide/creating-libraries#transitioning-libraries-to-partial-ivy-format for details 