### PR TITLE
fix(performance) Avoid the get to execute the check

### DIFF
--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -91,16 +91,15 @@ export class CookieService {
    * @since: 1.0.0
    */
   get(name: string): string {
-    if (this.documentIsAccessible && this.check(name)) {
-      name = encodeURIComponent(name);
-
-      const regExp: RegExp = CookieService.getCookieRegExp(name);
-      const result: RegExpExecArray = regExp.exec(this.document.cookie);
-
+    const nameEncoded = encodeURIComponent(name);
+    const regExp = CookieService.getCookieRegExp(nameEncoded);
+    const { cookie } = this.document;
+    
+    if (this.documentIsAccessible && regExp.test(cookie)) {
+      const result: RegExpExecArray = regExp.exec(cookie);
       return result[1] ? CookieService.safeDecodeURIComponent(result[1]) : '';
-    } else {
-      return '';
     }
+    return '';
   }
 
   /**


### PR DESCRIPTION
The method get was calling the check method before The check method was executing duplicated instructions like `encodeURIComponent`, `getCookieRegExp` and the verification of `this.documentIsAccessible` unnecessarily.

Proposing this change for performance reasons (even if minimal :alien:)