### PR TITLE
build(ci): The npm/action-setup is removed and replaced with actions/…

### DIFF
--- a/.github/workflows/npm_publish_ssr.yml
+++ b/.github/workflows/npm_publish_ssr.yml
@@ -9,9 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: npm/action-setup@v2
-        with:
-          version: latest
       - uses: actions/setup-node@v2
         with:
           node-version: 18


### PR DESCRIPTION
…setup-node for setting up the Node environment. It's configured to utilize the latest version of Node, ensuring the workflow is always running on the most recent release.