### PR TITLE
Export injection token of SSR service to give a chance provide it pro…

### DIFF
--- a/projects/ngx-cookie-service-ssr/README.md
+++ b/projects/ngx-cookie-service-ssr/README.md
@@ -132,12 +132,14 @@ Only install `ngx-cookie-service-ssr` library (and skip `ngx-cookie-service`) fo
 with this
 
 ```typescript
+import { REQUEST as NCSS_REQUEST } from "ngx-cookie-service-ssr";
+
 server.get('*', (req, res) => {
   res.render(indexHtml, {
     req,
     providers: [
       { provide: APP_BASE_HREF, useValue: req.baseUrl },
-      { provide: 'REQUEST', useValue: req },
+      { provide: NCSS_REQUEST, useValue: req },
       { provide: 'RESPONSE', useValue: res },
     ],
   });

--- a/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
+++ b/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
@@ -2,8 +2,10 @@ import { Request } from 'express';
 import { Inject, Injectable, InjectionToken, Optional, PLATFORM_ID } from '@angular/core';
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 
-// Define the `Request` token
-const REQUEST = new InjectionToken<Request>('REQUEST');
+/**
+ * Injection token to be provided in server.ts
+ */
+export const REQUEST = new InjectionToken<Request>('REQUEST');
 
 @Injectable({
   providedIn: 'root',


### PR DESCRIPTION
Ssr service does not work because it is unable to inject request properly and thus cant access cookie on server side. This PR exports injection token which can be used in server.ts to be properly provided to app. I also updated readme example with renamed export, because REQUEST token is often taken in apps.