### PR TITLE
feat(ssr): adds server cookie output via response

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "ng-packagr": "^16.0.0",
     "prettier": "^3.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "~5.1.6"
   }
 }

--- a/projects/ngx-cookie-service-ssr/package.json
+++ b/projects/ngx-cookie-service-ssr/package.json
@@ -25,6 +25,9 @@
   "contributors": [
     {
       "name": "Pavan Kumar Jadda"
+    },
+    {
+      "name": "Blake Ballard (blakeoxx)"
     }
   ],
   "repository": {


### PR DESCRIPTION
This fix/feature resolves #266 . It increases the `SsrCookieService`s ability to use the request and response objects provided by Express to read and write cookies on the server side. This also means that cookies written during SSR will be returned to the client in the response headers.

This PR is intended for a future release of v16 (16.2.0), up to maintainer discretion. If this PR passes code review, I can also port these changes forward to v17.