### PR TITLE
feat(ssr)(backport v16): adds server cookie output via response

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "ng-packagr": "^16.0.0",
     "prettier": "^3.0.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "~5.1.6"
   }
 }

--- a/projects/ngx-cookie-service-ssr/package.json
+++ b/projects/ngx-cookie-service-ssr/package.json
@@ -25,6 +25,9 @@
   "contributors": [
     {
       "name": "Pavan Kumar Jadda"
+    },
+    {
+      "name": "Blake Ballard (blakeoxx)"
     }
   ],
   "repository": {

--- a/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
+++ b/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
@@ -61,6 +61,8 @@ export class SsrCookieService {
    *
    * @author: Blake Ballard (blakeoxx)
    * @since: 16.2.0
+   * @see {@link https://github.com/stevermeister/ngx-cookie-service/blob/f7625d789dc18ea6aebcf136edb4cc01eeac5de9/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts#L100}
+   *  for previous implementation of parsing logic
    */
    static cookieStringToMap(cookieString: string): Map<string, string> {
     const cookies = new Map<string, string>;
@@ -92,6 +94,8 @@ export class SsrCookieService {
    *
    * @author: Blake Ballard (blakeoxx)
    * @since: 16.2.0
+   * @see {@link https://github.com/stevermeister/ngx-cookie-service/blob/f7625d789dc18ea6aebcf136edb4cc01eeac5de9/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts#L100}
+   *  for previous implementation of parsing logic
    */
   private getCombinedCookies(): Map<string, string> {
     if (this.documentIsAccessible) {
@@ -128,6 +132,7 @@ export class SsrCookieService {
    *
    * @author: Blake Ballard (blakeoxx)
    * @since: 16.2.0
+   * @see {@link set} for the original client-side cookie setter logic. This logic is mostly straight from there
    */
   private setClientCookie(
     name: string,


### PR DESCRIPTION
This fix/feature resolves #266 . It increases the `SsrCookieService`s ability to use the request and response objects provided by Express to read and write cookies on the server side. This also means that cookies written during SSR will be returned to the client in the response headers.

This PR is intended for a future release of v16 (16.2.0), up to maintainer discretion. If this PR passes code review, I can also port these changes forward to v17.

This PR was originally represented in https://github.com/stevermeister/ngx-cookie-service/pull/304, but was closed to resolve some attribution issues.