### PR TITLE
fix(core): result can be null in the regExp.exec return

### DIFF
--- a/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
+++ b/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
@@ -83,9 +83,9 @@ export class SsrCookieService {
       name = encodeURIComponent(name);
 
       const regExp: RegExp = SsrCookieService.getCookieRegExp(name);
-      const result: RegExpExecArray = regExp.exec(this.documentIsAccessible ? this.document.cookie : this.request?.headers.cookie);
+      const result: RegExpExecArray | null = regExp.exec(this.documentIsAccessible ? this.document.cookie : this.request?.headers.cookie);
 
-      return result[1] ? SsrCookieService.safeDecodeURIComponent(result[1]) : '';
+      return result?.[1] ? SsrCookieService.safeDecodeURIComponent(result[1]) : '';
     } else {
       return '';
     }

--- a/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.spec.ts
@@ -104,6 +104,16 @@ describe('NgxCookieServiceService', () => {
 
         expect(cookieService.get('bar')).toEqual('');
       });
+      it('should return empty string when there is no cookie', () => {
+        documentCookieGetterSpy.mockReturnValue('');
+
+        expect(cookieService.get('foo')).toEqual('');
+      });
+      it('should return empty string when there is no cookie', () => {
+        documentCookieGetterSpy.mockReturnValue(null);
+
+        expect(cookieService.get('foo')).toEqual('');
+      });
     });
     describe('#getAll', () => {
       it('should return empty object if cookies not set', () => {

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -96,9 +96,9 @@ export class CookieService {
       name = encodeURIComponent(name);
 
       const regExp: RegExp = CookieService.getCookieRegExp(name);
-      const result: RegExpExecArray = regExp.exec(this.document.cookie);
+      const result: RegExpExecArray | null = regExp.exec(this.document.cookie);
 
-      return result[1] ? CookieService.safeDecodeURIComponent(result[1]) : '';
+      return result?.[1] ? CookieService.safeDecodeURIComponent(result[1]) : '';
     } else {
       return '';
     }


### PR DESCRIPTION
Some times in my project the result can be null so this PR allow the result to be null.