### PR TITLE
chore: remove unnecessary check

### DIFF
--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -92,7 +92,7 @@ export class CookieService {
    * @since: 1.0.0
    */
   get(name: string): string {
-    if (this.documentIsAccessible && this.check(name)) {
+    if (this.check(name)) {
       name = encodeURIComponent(name);
 
       const regExp: RegExp = CookieService.getCookieRegExp(name);


### PR DESCRIPTION
The additional check documentIsAccessible in get() is not necessary, because it is done in check() anyway