### PR TITLE
fix: remove statefulness from cookie regex implementation

### DIFF
--- a/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
+++ b/projects/ngx-cookie-service-ssr/src/lib/ssr-cookie.service.ts
@@ -21,10 +21,11 @@ export class SsrCookieService {
    * @author: Stepan Suvorov
    * @since: 1.0.0
    */
-  static getCookieRegExp(name: string): RegExp {
-    const escapedName: string = name.replace(/([[\]{}()|=;+?,.*^$\\])/gi, '\\$1');
+  private static getCookieRegExp(name: string): RegExp {
+    const escapedName = name.replace(/([[\]{}()|=;+?,.*^$\\])/gi, '\\$1');
 
-    return new RegExp('(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)', 'g');
+    // No "g" flag => no lastIndex statefulness.
+    return new RegExp('(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)');
   }
 
   /**

--- a/projects/ngx-cookie-service/src/lib/cookie.service.ts
+++ b/projects/ngx-cookie-service/src/lib/cookie.service.ts
@@ -34,9 +34,10 @@ export class CookieService {
    * @since: 1.0.0
    */
   private static getCookieRegExp(name: string): RegExp {
-    const escapedName: string = name.replace(/([[\]{}()|=;+?,.*^$\\])/gi, '\\$1');
+    const escapedName = name.replace(/([[\]{}()|=;+?,.*^$\\])/gi, '\\$1');
 
-    return new RegExp('(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)', 'g');
+    // No "g" flag => no lastIndex statefulness.
+    return new RegExp('(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)');
   }
 
   /**


### PR DESCRIPTION
closes https://github.com/stevermeister/ngx-cookie-service/issues/380